### PR TITLE
feat: chat UX polish and client error reporting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "skill-creator@claude-plugins-official": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ postgres_data/
 
 # Drawio
 *.drawio.bkp
+
+# Claude
+.claude/worktrees

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+RAGTube is a RAG (Retrieval Augmented Generation) application for querying YouTube transcriptions. It uses pgvector for vector storage, Ollama for embeddings/chat, FastAPI for the backend, and a Vanilla JS + shadcn/ui frontend.
+
+## Commands
+
+### Backend (run from `backend/`)
+
+```bash
+uv sync --all-extras                          # Install dependencies
+uv run uvicorn ragtube.api.app:app --host 0.0.0.0 --port 5000 --log-config log_config.yaml  # Run API
+uv run python -m ragtube.cli.app update_index # Ingest transcripts
+uv run pytest                                 # Run all tests
+uv run pytest tests/unit/services/test_retriever.py  # Single test file
+uv run pytest --cov=ragtube --cov-report=html # Tests with coverage
+uv run ruff check --fix ragtube/              # Lint
+uv run ruff format ragtube/                   # Format
+uv run pyright ragtube/                          # Type check
+```
+
+### Frontend (run from `frontend/`)
+
+```bash
+npm install                   # Install dependencies
+npm run dev                   # Dev server on port 8501
+npm run build                 # Production build
+npm run format                # Format with Prettier
+npm run format:check          # Check formatting
+```
+
+### Docker
+
+```bash
+docker compose up             # Run full stack
+```
+
+## Architecture
+
+### Backend (`backend/ragtube/`)
+
+- **`api/app.py`** - FastAPI app with endpoints: `/readiness`, `/channel`, `/rag`
+- **`cli/app.py`** - Typer CLI for data ingestion (`update_index`)
+- **`core/`** - Database engine (`database.py`), SQLModel schemas (`models.py`), YAML config (`params.py`), env secrets (`settings.py`)
+- **`data/`** - YouTube transcript fetching (`transcript.py`) and text chunking (`chunk.py`)
+- **`services/`** - RAG pipeline: embedding (Ollama) -> retrieval (pgvector HNSW) -> rerank (FlashRank) -> chat (Ollama via LangChain)
+
+**RAG request flow:** Query hits `/rag` -> embed query -> pgvector HNSW retrieval -> FlashRank reranking -> Ollama generates answer -> NDJSON streaming response (`{"context": [...]}` then `{"answer": "..."}` tokens).
+
+**DB models:** Channel -> Video -> Caption -> Chunk (with `embedding: Vector`). Tables auto-created by SQLModel (`create_all`), no migration tool.
+
+### Frontend (`frontend/src/`)
+
+Vanilla JS SPA with Vite, Tailwind CSS, and shadcn/ui components. Key files: `main.js` (entry), `api/client.js` (API client with NDJSON streaming), `components/chat-interface.js`, `components/channel-selector.js`.
+
+### Configuration
+
+- **`.env`** (root) - Secrets: `YOUTUBE_API_KEY`, `DB_*`, `HOSTNAME`, `OLLAMA_HOST`
+- **`params.yaml`** (root) - App config: channel IDs, model names, chunk sizes, HNSW params, rerank thresholds. Searched in: env var path -> package dir -> repo root -> `/app/`
+- Both are cached via `@lru_cache` - restart required after edits
+
+### Pre-commit hooks
+
+Ruff linting/formatting and basic file hygiene (trailing whitespace, end-of-file, YAML check) run automatically on commit.
+
+### CI/CD
+
+- **PR pipeline** (`.github/workflows/onpr.yaml`): ruff + pytest with coverage (backend), Prettier check (frontend)
+- **Release pipeline** (`.github/workflows/onrelease.yaml`): Multi-arch Docker builds on tag push, published to Docker Hub and GHCR

--- a/backend/ragtube/api/app.py
+++ b/backend/ragtube/api/app.py
@@ -81,6 +81,15 @@ class RAGError(Exception):
     response: dict = {}
 
 
+class ClientErrorReport(BaseModel):
+    message: str
+    stack: str | None = None
+    url: str | None = None
+    user_agent: str | None = None
+    timestamp: datetime | None = None
+    context: str | None = None
+
+
 app = FastAPI()
 security = HTTPBasic()
 
@@ -104,8 +113,25 @@ app.add_middleware(
 )
 
 
+logger = logging.getLogger("ragtube.api")
+
+
 @app.get("/readiness")
 async def readiness():
+    return {"status": "ok"}
+
+
+@app.post("/log/client-error")
+async def log_client_error(report: ClientErrorReport):
+    logger.warning(
+        "client error: %s | context=%s url=%s ua=%s",
+        report.message,
+        report.context,
+        report.url,
+        report.user_agent,
+    )
+    if report.stack:
+        logger.warning("client error stack:\n%s", report.stack)
     return {"status": "ok"}
 
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,9 @@
         "@radix-ui/react-tooltip": "^1.0.7",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
+        "dompurify": "^3.2.0",
         "lucide": "^0.293.0",
+        "marked": "^14.1.0",
         "tailwind-merge": "^2.1.0",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -1685,6 +1687,13 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
@@ -2013,6 +2022,15 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -2362,6 +2380,18 @@
       "resolved": "https://registry.npmjs.org/lucide/-/lucide-0.293.0.tgz",
       "integrity": "sha512-LTL2scS6yZi6Owm0uKQtgV1VuUXa2DdgLEAEjUvasV3KtGuRKldZzhqcf4l3nSSA0kgSyicjfUkScnEI3eSwxg==",
       "license": "ISC"
+    },
+    "node_modules/marked": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.4.tgz",
+      "integrity": "sha512-vkVZ8ONmUdPnjCKc5uTRvmkRbx4EAi2OkTOXmfTDhZz3OFqMNBM1oTTWwTr4HY4uAEojhzPf+Fy8F1DWa3Sndg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,9 @@
     "@radix-ui/react-tooltip": "^1.0.7",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
+    "dompurify": "^3.2.0",
     "lucide": "^0.293.0",
+    "marked": "^14.1.0",
     "tailwind-merge": "^2.1.0",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -41,7 +41,7 @@ export class APIClient {
     }
   }
 
-  async *streamRAGResponse(input, channelId = null) {
+  async *streamRAGResponse(input, channelId = null, signal = null) {
     try {
       const params = new URLSearchParams({ input })
       if (channelId) {
@@ -53,6 +53,7 @@ export class APIClient {
         headers: {
           Accept: 'application/x-ndjson',
         },
+        signal,
       })
 
       if (!response.ok) {
@@ -99,7 +100,9 @@ export class APIClient {
         reader.releaseLock()
       }
     } catch (error) {
-      console.error('RAG stream error:', error)
+      if (error.name !== 'AbortError') {
+        console.error('RAG stream error:', error)
+      }
       throw error
     }
   }

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -15,6 +15,28 @@ export class APIClient {
     }
   }
 
+  reportError(error, context) {
+    if (error && error.name === 'AbortError') return
+    try {
+      fetch(`${this.baseURL}/log/client-error`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          message: error?.message || String(error),
+          stack: error?.stack || null,
+          url: typeof window !== 'undefined' ? window.location.href : null,
+          user_agent:
+            typeof navigator !== 'undefined' ? navigator.userAgent : null,
+          timestamp: new Date().toISOString(),
+          context: context || null,
+        }),
+        keepalive: true,
+      }).catch(err => console.warn('Failed to report client error:', err))
+    } catch (err) {
+      console.warn('Failed to report client error:', err)
+    }
+  }
+
   async checkReadiness() {
     try {
       const response = await fetch(`${this.baseURL}/readiness`)
@@ -24,6 +46,7 @@ export class APIClient {
       return await response.json()
     } catch (error) {
       console.error('Readiness check failed:', error)
+      this.reportError(error, 'checkReadiness')
       throw error
     }
   }
@@ -37,6 +60,7 @@ export class APIClient {
       return await response.json()
     } catch (error) {
       console.error('Failed to fetch channels:', error)
+      this.reportError(error, 'getChannels')
       throw error
     }
   }
@@ -102,6 +126,7 @@ export class APIClient {
     } catch (error) {
       if (error.name !== 'AbortError') {
         console.error('RAG stream error:', error)
+        this.reportError(error, 'streamRAGResponse')
       }
       throw error
     }

--- a/frontend/src/components/chat-interface.js
+++ b/frontend/src/components/chat-interface.js
@@ -58,6 +58,7 @@ export function createChatInterface(apiClient) {
       'absolute right-1.5 sm:right-2 bottom-1.5 sm:bottom-2 h-7 w-7 sm:h-8 sm:w-8 rounded-full',
     children: createSendIcon(),
   })
+  sendButton.setAttribute('aria-label', 'Send')
 
   inputForm.appendChild(messageInput)
   inputForm.appendChild(sendButton)
@@ -70,17 +71,26 @@ export function createChatInterface(apiClient) {
   // State management
   let currentChannelId = null
   let isLoading = false
+  let abortController = null
 
   // Listen for channel changes
   document.addEventListener('channelChanged', event => {
     currentChannelId = event.detail.channelId
   })
 
-  // Handle Enter key in textarea (Ctrl+Enter or Cmd+Enter to send)
+  // Enter sends, Shift+Enter inserts a newline (standard chat UX)
   messageInput.addEventListener('keydown', e => {
-    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+    if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
       inputForm.dispatchEvent(new Event('submit'))
+    }
+  })
+
+  // Click handler: send (when idle) or abort (when streaming)
+  sendButton.addEventListener('click', e => {
+    if (isLoading && abortController) {
+      e.preventDefault()
+      abortController.abort()
     }
   })
 
@@ -110,6 +120,8 @@ export function createChatInterface(apiClient) {
     messagesContainer.appendChild(typingIndicator)
     scrollToBottom()
 
+    abortController = new AbortController()
+
     try {
       isLoading = true
       updateLoadingState(true)
@@ -134,7 +146,8 @@ export function createChatInterface(apiClient) {
 
       for await (const response of apiClient.streamRAGResponse(
         message,
-        currentChannelId
+        currentChannelId,
+        abortController.signal
       )) {
         if (response.context && !contextDisplayed) {
           typingIndicator.remove()
@@ -156,7 +169,8 @@ export function createChatInterface(apiClient) {
       if (assistantMessage) {
         const contentElement =
           assistantMessage.querySelector('.message-content')
-        contentElement.innerHTML = renderMarkdown(answerBuffer)
+        const suffix = abortController.signal.aborted ? '\n\n_(stopped)_' : ''
+        contentElement.innerHTML = renderMarkdown(answerBuffer + suffix)
         scrollToBottom()
       }
 
@@ -172,20 +186,25 @@ export function createChatInterface(apiClient) {
         scrollToBottom()
       }
     } catch (error) {
-      console.error('Chat error:', error)
-      typingIndicator.remove()
+      if (error.name === 'AbortError') {
+        typingIndicator.remove()
+      } else {
+        console.error('Chat error:', error)
+        typingIndicator.remove()
 
-      const errorMessage = createMessage({
-        role: 'assistant',
-        content:
-          'I apologize, but I encountered an error while processing your request. Please try again.',
-        timestamp: new Date(),
-        isError: true,
-      })
-      messagesContainer.appendChild(errorMessage)
-      scrollToBottom()
+        const errorMessage = createMessage({
+          role: 'assistant',
+          content:
+            'I apologize, but I encountered an error while processing your request. Please try again.',
+          timestamp: new Date(),
+          isError: true,
+        })
+        messagesContainer.appendChild(errorMessage)
+        scrollToBottom()
+      }
     } finally {
       isLoading = false
+      abortController = null
       updateLoadingState(false)
     }
   })
@@ -195,13 +214,16 @@ export function createChatInterface(apiClient) {
   }
 
   function updateLoadingState(loading) {
-    sendButton.disabled = loading
     messageInput.disabled = loading
-
+    sendButton.innerHTML = ''
     if (loading) {
-      sendButton.classList.add('opacity-50', 'cursor-not-allowed')
+      sendButton.appendChild(createStopIcon())
+      sendButton.setAttribute('aria-label', 'Stop generating')
+      sendButton.title = 'Stop generating'
     } else {
-      sendButton.classList.remove('opacity-50', 'cursor-not-allowed')
+      sendButton.appendChild(createSendIcon())
+      sendButton.setAttribute('aria-label', 'Send')
+      sendButton.title = 'Send'
     }
   }
 
@@ -577,6 +599,17 @@ function createSendIcon() {
   const icon = document.createElement('span')
   icon.innerHTML = '↑'
   icon.className = 'text-base font-bold'
+  return icon
+}
+
+function createStopIcon() {
+  const icon = document.createElement('span')
+  icon.className = 'flex items-center justify-center'
+  icon.innerHTML = `
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor">
+      <rect x="2" y="2" width="8" height="8" rx="1"/>
+    </svg>
+  `
   return icon
 }
 

--- a/frontend/src/components/chat-interface.js
+++ b/frontend/src/components/chat-interface.js
@@ -193,7 +193,6 @@ export function createChatInterface(apiClient) {
       }
 
       if (!assistantMessage) {
-        // Remove typing indicator and show no results
         typingIndicator.remove()
         const noResultsMessage = createMessage({
           role: 'assistant',
@@ -205,6 +204,7 @@ export function createChatInterface(apiClient) {
       }
     } catch (error) {
       if (error.name === 'AbortError') {
+        // Graceful abort — treat like a clean stop
         typingIndicator.remove()
       } else {
         console.error('Chat error:', error)
@@ -212,8 +212,7 @@ export function createChatInterface(apiClient) {
 
         const errorMessage = createMessage({
           role: 'assistant',
-          content:
-            'I apologize, but I encountered an error while processing your request. Please try again.',
+          content: `Something went wrong: ${error.message || error}. Please try again.`,
           timestamp: new Date(),
           isError: true,
         })

--- a/frontend/src/components/chat-interface.js
+++ b/frontend/src/components/chat-interface.js
@@ -3,6 +3,7 @@ import { createButton } from './ui/button.js'
 import { createScrollArea } from './ui/scroll-area.js'
 import { createAvatar, createAvatarFallback } from './ui/avatar.js'
 import { formatTime, formatDate } from '../utils/helpers.js'
+import { renderMarkdown } from '../utils/markdown.js'
 
 export function createChatInterface(apiClient) {
   const container = document.createElement('div')
@@ -114,17 +115,29 @@ export function createChatInterface(apiClient) {
       updateLoadingState(true)
 
       let assistantMessage = null
+      let answerBuffer = ''
       let contextDisplayed = false
+      let rafPending = false
+
+      const scheduleRender = () => {
+        if (rafPending || !assistantMessage) return
+        rafPending = true
+        requestAnimationFrame(() => {
+          rafPending = false
+          if (!assistantMessage) return
+          const contentElement =
+            assistantMessage.querySelector('.message-content')
+          contentElement.innerHTML = renderMarkdown(answerBuffer)
+          scrollToBottom()
+        })
+      }
 
       for await (const response of apiClient.streamRAGResponse(
         message,
         currentChannelId
       )) {
         if (response.context && !contextDisplayed) {
-          // Remove typing indicator
           typingIndicator.remove()
-
-          // Create assistant message with context
           assistantMessage = createMessage({
             role: 'assistant',
             content: '',
@@ -135,12 +148,16 @@ export function createChatInterface(apiClient) {
           contextDisplayed = true
           scrollToBottom()
         } else if (response.answer && assistantMessage) {
-          // Stream the answer
-          const contentElement =
-            assistantMessage.querySelector('.message-content')
-          contentElement.textContent += response.answer
-          scrollToBottom()
+          answerBuffer += response.answer
+          scheduleRender()
         }
+      }
+
+      if (assistantMessage) {
+        const contentElement =
+          assistantMessage.querySelector('.message-content')
+        contentElement.innerHTML = renderMarkdown(answerBuffer)
+        scrollToBottom()
       }
 
       if (!assistantMessage) {
@@ -229,7 +246,11 @@ function createMessage({
   messageContent.className = `message-content text-sm leading-relaxed ${
     isError ? 'text-destructive' : ''
   }`
-  messageContent.textContent = content
+  if (role === 'assistant' && !isError && content) {
+    messageContent.innerHTML = renderMarkdown(content)
+  } else {
+    messageContent.textContent = content
+  }
 
   // Timestamp - smaller and less prominent
   const timestampDiv = document.createElement('div')

--- a/frontend/src/components/chat-interface.js
+++ b/frontend/src/components/chat-interface.js
@@ -5,6 +5,24 @@ import { createAvatar, createAvatarFallback } from './ui/avatar.js'
 import { formatTime, formatDate } from '../utils/helpers.js'
 import { renderMarkdown } from '../utils/markdown.js'
 
+const CONTEXT_PREF_KEY = 'ragtube:contextExpanded'
+
+function getContextPref() {
+  try {
+    return localStorage.getItem(CONTEXT_PREF_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+function setContextPref(expanded) {
+  try {
+    localStorage.setItem(CONTEXT_PREF_KEY, String(expanded))
+  } catch {
+    // localStorage unavailable; fail silently
+  }
+}
+
 export function createChatInterface(apiClient) {
   const container = document.createElement('div')
   container.className = 'flex-1 flex flex-col min-h-0'
@@ -332,19 +350,20 @@ function createContextDisplay(context) {
   const contextCard = document.createElement('div')
   contextCard.className = 'mt-3 bg-card border rounded-lg overflow-visible'
 
+  const startExpanded = getContextPref()
+
   const header = document.createElement('div')
   header.className =
     'px-3 sm:px-4 py-2 bg-muted/50 rounded-t-lg border-b cursor-pointer flex items-center justify-between'
   header.innerHTML = `
     <span class="text-sm font-medium">Retrieved Context (${context.length} sources)</span>
-    <svg class="w-4 h-4 transition-transform context-chevron" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <svg class="w-4 h-4 transition-transform context-chevron" fill="none" stroke="currentColor" viewBox="0 0 24 24" style="transform: rotate(${startExpanded ? 180 : 0}deg)">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   `
 
   const content = document.createElement('div')
-  content.className =
-    'hidden context-content p-2 sm:p-4 space-y-3 sm:space-y-6 overflow-hidden'
+  content.className = `${startExpanded ? '' : 'hidden '}context-content p-2 sm:p-4 space-y-3 sm:space-y-6 overflow-hidden`
   content.style.maxHeight = 'none'
   content.style.height = 'auto'
 
@@ -556,6 +575,7 @@ function createContextDisplay(context) {
   header.addEventListener('click', () => {
     const isHidden = content.classList.contains('hidden')
     const chevron = header.querySelector('.context-chevron')
+    setContextPref(isHidden)
 
     if (isHidden) {
       content.classList.remove('hidden')

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -154,3 +154,78 @@
 .typing-indicator span:nth-child(3) {
   animation-delay: 0.4s;
 }
+
+/* Markdown prose styles for assistant messages */
+.message-content p {
+  margin: 0 0 0.5rem 0;
+}
+.message-content p:last-child {
+  margin-bottom: 0;
+}
+.message-content ul,
+.message-content ol {
+  margin: 0.25rem 0 0.5rem 0;
+  padding-left: 1.25rem;
+}
+.message-content ul {
+  list-style: disc;
+}
+.message-content ol {
+  list-style: decimal;
+}
+.message-content li {
+  margin: 0.125rem 0;
+}
+.message-content strong {
+  font-weight: 600;
+}
+.message-content em {
+  font-style: italic;
+}
+.message-content code {
+  background: hsl(var(--muted));
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.25rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.875em;
+}
+.message-content pre {
+  background: hsl(var(--muted));
+  padding: 0.75rem;
+  border-radius: 0.375rem;
+  overflow-x: auto;
+  margin: 0.5rem 0;
+}
+.message-content pre code {
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  font-size: 0.875em;
+}
+.message-content blockquote {
+  border-left: 3px solid hsl(var(--border));
+  padding-left: 0.75rem;
+  margin: 0.5rem 0;
+  color: hsl(var(--muted-foreground));
+}
+.message-content a {
+  color: hsl(var(--primary));
+  text-decoration: underline;
+}
+.message-content h1,
+.message-content h2,
+.message-content h3,
+.message-content h4 {
+  font-weight: 600;
+  margin: 0.75rem 0 0.375rem 0;
+  line-height: 1.3;
+}
+.message-content h1 {
+  font-size: 1.25em;
+}
+.message-content h2 {
+  font-size: 1.125em;
+}
+.message-content h3 {
+  font-size: 1em;
+}

--- a/frontend/src/utils/markdown.js
+++ b/frontend/src/utils/markdown.js
@@ -1,0 +1,11 @@
+import { marked } from 'marked'
+import DOMPurify from 'dompurify'
+
+marked.setOptions({
+  breaks: true,
+  gfm: true,
+})
+
+export function renderMarkdown(text) {
+  return DOMPurify.sanitize(marked.parse(text))
+}


### PR DESCRIPTION
## Summary

Five atomic frontend/backend changes that polish the chat experience and add observability for client-side failures:

- **Markdown rendering** — assistant messages are parsed with `marked` and sanitized with `DOMPurify`; tokens accumulate in a buffer and re-render once per animation frame to stay smooth while streaming. Adds prose styles for lists, code blocks, blockquotes, headings, etc.
- **Enter-to-send + Stop button** — Enter submits, Shift+Enter inserts a newline (replaces Ctrl/Cmd+Enter). While streaming, the send button becomes a Stop button that aborts the in-flight request via `AbortController`; any partial output is kept with a `_(stopped)_` suffix.
- **Persisted context preference** — the Retrieved Context panel remembers its expanded/collapsed state in `localStorage` across messages and reloads.
- **Real error details in UI** — the generic "I apologize..." message is replaced with the actual error detail so users can report what broke.
- **Client error log endpoint** — new `POST /log/client-error` on the backend receives fire-and-forget error reports from the frontend (`checkReadiness`, `getChannels`, `streamRAGResponse` catches) and logs them at WARNING level.

Also includes earlier chore commits already on the branch: `.claude/worktrees` gitignore entry, `CLAUDE.md`, and the skill-creator skill.

## Test plan

- [ ] `cd frontend && npm install && npm run dev` — dev server on :8501
- [ ] `cd backend && uv run uvicorn ragtube.api.app:app --host 0.0.0.0 --port 5000 --log-config log_config.yaml`
- [ ] **Markdown**: ask a question that elicits a list or code block — renders as HTML, not literal `*` / backticks
- [ ] **Enter/Stop**: Enter sends, Shift+Enter inserts newline; clicking Stop during stream halts with `(stopped)` suffix and partial output preserved
- [ ] **Context pref**: expand Retrieved Context on one message, send another or reload — stays expanded; collapse + reload — stays collapsed
- [ ] **Errors**: stop the backend, send a message — UI shows the real error; restart backend and check for a WARNING log from `/log/client-error`
- [ ] `cd frontend && npm run format:check` and `cd backend && uv run ruff check && uv run pyright ragtube/ && uv run pytest` all pass